### PR TITLE
[Feature] Make it optional whether to hide the default cast bar

### DIFF
--- a/Data/Defaults.lua
+++ b/Data/Defaults.lua
@@ -456,6 +456,7 @@ Defaults.Widgets = {
 ---@field widgets WidgetTables
 ---@field tooltipPosition TooltipPosition
 ---@field sameSizeAsPlayer boolean?
+---@field hideBlizzardCastBar boolean?
 
 ---@alias UnitLayoutTable table<Unit, UnitLayout>
 ---@type UnitLayoutTable
@@ -468,6 +469,7 @@ Defaults.Layouts = {
         position = { 800, 500 },
         widgets = Defaults.Widgets,
         tooltipPosition = { "BOTTOMLEFT", "BOTTOMLEFT", -3, 0, },
+        hideBlizzardCastBar = false,
     },
     target = {
         enabled = false,

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -143,6 +143,9 @@ L.CreatedAutomaticBackup = "New version detected. Created backups for:"
 L.CreatedManualBackup = "Created manual backups for:"
 L.Backup_manual = "Manual Backup"
 L.Backup_automatic = "Automatic Backup"
+L.HideDefaultCastBar = "Hide Default Cast Bar"
+L.HideDefaultCastBarTooltip = [[Hides the default cast bar.
+Reload to show it again after disabling this option.]]
 
 -- Custom Formats
 L.ValidTags = "Valid Tags"

--- a/UnitFrames/MenuOptions.lua
+++ b/UnitFrames/MenuOptions.lua
@@ -39,6 +39,8 @@ local function AddLoadPageDB(unitPage)
         -- same as player
         if not isPlayerPage then
             unitPage.sameSizeAsPlayerCB:SetChecked(isSameSizeAsPlayer)
+        else
+            unitPage.hideBlizzardCastBarCB:SetChecked(pageDB.hideBlizzardCastBar)
         end
 
         if isPlayerPage then
@@ -130,6 +132,14 @@ local function AddUnitsToMenu()
                             end
                         end)
                     unitPage.sameSizeAsPlayerCB:SetPoint("TOPLEFT", unitPage.enabledCB, "TOPRIGHT", 200, 0)
+                else
+                    -- Disable blizzard cast bar
+                    unitPage.hideBlizzardCastBarCB = Cell:CreateCheckButton(unitPage.frame, L.HideDefaultCastBar,
+                        function(checked)
+                            CUF.DB.SelectedLayoutTable()[unit].hideBlizzardCastBar = checked
+                            CUF:Fire("UpdateVisibility", unit)
+                        end, L.HideDefaultCastBarTooltip)
+                    unitPage.hideBlizzardCastBarCB:SetPoint("TOPLEFT", unitPage.enabledCB, "TOPRIGHT", 200, 0)
                 end
 
                 ---@type CellSlider

--- a/Util/HideBlizzard.lua
+++ b/Util/HideBlizzard.lua
@@ -49,7 +49,12 @@ end
 function CUF:HideBlizzardUnitFrame(unit)
     if unit == "player" and _G.PlayerFrame then
         HideFrame(_G.PlayerFrame)
-        PlayerCastingBarFrame:UnregisterAllEvents()
+
+        if CUF.DB.CurrentLayoutTable()[unit].hideBlizzardCastBar then
+            if _G.PlayerCastingBarFrame then
+                HideFrame(_G.PlayerCastingBarFrame)
+            end
+        end
     elseif unit == "target" and _G.TargetFrame then
         HideFrame(_G.TargetFrame)
     elseif unit == "focus" and _G.FocusFrame then


### PR DESCRIPTION
Implements a new toggle for Player unit that hides the default cast bar.