### PR TITLE
Add option to invert health colors if unit is attackable/enemy.

### DIFF
--- a/Data/Defaults.lua
+++ b/Data/Defaults.lua
@@ -117,6 +117,7 @@ Defaults.Options.fontWidth = {
 ---| "runes"
 ---| "shieldBar"
 ---| "healAbsorb"
+---| "hostileUnits"
 
 ---@class Defaults.Colors
 Defaults.Colors = {
@@ -185,6 +186,9 @@ Defaults.Colors = {
         color = { 1, 0.1, 0.1, 1 },
         overAbsorb = { 1, 1, 1, 1 },
         invertColor = false,
+    },
+    hostileUnits = {
+        swapHealthAndLossColors = false,
     }
 }
 
@@ -255,6 +259,9 @@ Defaults.ColorsMenuOrder = {
         { "color",       "rgb" },
         { "overAbsorb",  "rgb" },
         { "invertColor", "toggle" },
+    },
+    hostileUnits = {
+        { "swapHealthAndLossColors", "toggle" }
     }
 }
 

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -242,6 +242,8 @@ L.classResources = "Class Resources"
 L.useClassColorForPet = "Use Class Color for Pet"
 L.overShield = "Overshield"
 L.overAbsorb = "Overabsorb"
+L.hostileUnits = 'Hostile Units'
+L.swapHealthAndLossColors = 'Swap Health and Heath Loss Colors'
 
 L.reaction = "Reaction"
 L.friendly = "Friendly"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -243,7 +243,7 @@ L.useClassColorForPet = "Use Class Color for Pet"
 L.overShield = "Overshield"
 L.overAbsorb = "Overabsorb"
 L.hostileUnits = 'Hostile Units'
-L.swapHealthAndLossColors = 'Swap Health and Heath Loss Colors'
+L.swapHealthAndLossColors = 'Swap Health and Health Loss Colors'
 
 L.reaction = "Reaction"
 L.friendly = "Friendly"

--- a/Widgets/Bars/HealthBar.lua
+++ b/Widgets/Bars/HealthBar.lua
@@ -30,10 +30,16 @@ function U:UnitFrame_UpdateHealthColor(button)
     local barR, barG, barB
     local lossR, lossG, lossB
     local barA, lossA = 1, 1
+    local healthPct = button.states.healthPercent
 
     if Cell.loaded then
         barA = CellDB["appearance"]["barAlpha"]
         lossA = CellDB["appearance"]["lossAlpha"]
+    end
+
+    local swapHealthAndLossColors = CUF.DB.GetColors().hostileUnits.swapHealthAndLossColors and (UnitCanAttack('player', unit) or not UnitIsFriend('player', unit))
+    if healthPct ~= nil and swapHealthAndLossColors then
+        healthPct = 1 - healthPct
     end
 
     if not UnitIsConnected(unit) then
@@ -43,15 +49,20 @@ function U:UnitFrame_UpdateHealthColor(button)
         barR, barG, barB, barA = 0.5, 0, 1, 1
         lossR, lossG, lossB, lossA = barR * 0.2, barG * 0.2, barB * 0.2, 1
     elseif button.states.inVehicle then
-        barR, barG, barB, lossR, lossG, lossB = F:GetHealthBarColor(button.states.healthPercent,
+        barR, barG, barB, lossR, lossG, lossB = F:GetHealthBarColor(healthPct,
             button.states.isDeadOrGhost or button.states.isDead, 0, 1, 0.2)
     else
-        barR, barG, barB, lossR, lossG, lossB = F:GetHealthBarColor(button.states.healthPercent,
+        barR, barG, barB, lossR, lossG, lossB = F:GetHealthBarColor(healthPct,
             button.states.isDeadOrGhost or button.states.isDead, CUF.Util:GetUnitClassColor(button.states.unit))
     end
 
-    button.widgets.healthBar:SetStatusBarColor(barR, barG, barB, barA)
-    button.widgets.healthBarLoss:SetVertexColor(lossR, lossG, lossB, lossA)
+    if swapHealthAndLossColors then
+        button.widgets.healthBar:SetStatusBarColor(lossR, lossG, lossB, lossA)
+        button.widgets.healthBarLoss:SetVertexColor(barR, barG, barB, barA)
+    else
+        button.widgets.healthBar:SetStatusBarColor(barR, barG, barB, barA)
+        button.widgets.healthBarLoss:SetVertexColor(lossR, lossG, lossB, lossA)
+    end
 
     --[[ if Cell.loaded and CellDB["appearance"]["healPrediction"][2] then
         self.widgets.incomingHeal:SetVertexColor(CellDB["appearance"]["healPrediction"][3][1], CellDB["appearance"]["healPrediction"][3][2], CellDB["appearance"]["healPrediction"][3][3], CellDB["appearance"]["healPrediction"][3][4])


### PR DESCRIPTION
Fixes #104

(ignore typo in 'Health', fixed in 2nd commit)
![Screenshot 2024-10-07 172106](https://github.com/user-attachments/assets/0a0fbc75-0997-4303-83cc-77415ee34e1e)

https://github.com/user-attachments/assets/deac4255-cd95-40e4-902d-d3dfa09bfbaa

