### PR TITLE
[Feature] allow negative spacing for classbars

### DIFF
--- a/Menu/Builder.lua
+++ b/Menu/Builder.lua
@@ -1613,7 +1613,7 @@ function Builder:CreateClassBarOptions(parent, widgetName)
     f.sizeOptions = self:CreateSizeOptions(f, widgetName, 0, 500)
     self:AnchorBelow(f.sizeOptions, f.anchorOptions.anchorDropdown)
 
-    f.spacing = self:CreateSlider(f, widgetName, L["Spacing"], nil, 0, 50,
+    f.spacing = self:CreateSlider(f, widgetName, L["Spacing"], nil, -1, 50,
         const.OPTION_KIND.SPACING)
     self:AnchorRight(f.spacing, f.sizeOptions.sizeHeightSlider)
 

--- a/Widgets/Bars/ClassBar.lua
+++ b/Widgets/Bars/ClassBar.lua
@@ -168,9 +168,9 @@ local function UpdateSize(self)
 
     local maxWidth
     if self.sameSizeAsHealthBar then
-        maxWidth = self._owner:GetWidth()
+        maxWidth = self._owner:GetWidth() + (self.spacing == -1 and -1 or 0)
     else
-        maxWidth = self.width
+        maxWidth = self.width + (self.spacing == -1 and -1 or 0)
     end
     self:SetSize(maxWidth, self.height)
 


### PR DESCRIPTION
Allows the classbar spacing to be minus 1 for cleaner borders.

![image](https://github.com/user-attachments/assets/6dbbd133-596a-40f8-b197-b245311bdcad)


Before:
![image](https://github.com/user-attachments/assets/4ca3a2a0-c5e7-4acd-a6e5-bf0579f3a080)

After:
![image](https://github.com/user-attachments/assets/c28746f4-c937-47b8-8d80-485fc4d6ff7b)

--- 

Thanks for implementing my suggestion regarding classBar textures, let me know if I need to anything different in regards to contributing. 
