### PR TITLE
Classic Era Support: Ease Dependency on Cell's LibGroupInfo

### DIFF
--- a/Widgets/Bars/PowerBar.lua
+++ b/Widgets/Bars/PowerBar.lua
@@ -4,7 +4,7 @@ local CUF = select(2, ...)
 local Cell = CUF.Cell
 local F = Cell.funcs
 ---@type LibGroupInfo
-local LGI = LibStub:GetLibrary("LibGroupInfo")
+local LGI = LibStub:GetLibrary("LibGroupInfo", true)
 
 ---@class CUF.widgets
 local W = CUF.widgets
@@ -36,7 +36,7 @@ local function GetRole(button)
         return button.states.role
     end
 
-    local info = LGI:GetCachedInfo(button.states.guid)
+    local info = LGI and LGI:GetCachedInfo(button.states.guid)
     if not info then return end
     return info.role
 end


### PR DESCRIPTION
I'm working on getting the addon functional in Classic Era for the upcoming anniversary servers.
Cell does not load `LibGroupInfo` in the `LoadLibs_Classic.xml` any more, which is used in its `Cell_Vanilla.toc`.

Since the dependency on LGI is pretty minor I was hoping this was an acceptable solution. ƪ(˘⌣˘)ʃ

1. Make Lib load silent
2. Check for lib table before accessing it