### PR TITLE
Classic Era Support: Seperate .toc & general support

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -3,6 +3,9 @@ package-as: Cell_UnitFrames
 required-dependencies:
   - cell
 
+externals:
+  Libs/!BlizzPolyfill: https://github.com/inyawfaze/BlizzPolyfill
+
 manual-changelog:
   filename: CHANGELOG.md
   markup-type: markdown

--- a/Cell_UnitFrames_Vanilla.toc
+++ b/Cell_UnitFrames_Vanilla.toc
@@ -1,0 +1,90 @@
+## Interface: 11504
+## SavedVariables: CUF_DB
+## IconTexture: Interface\ICONS\spell_progenitor_buff
+
+## Title: Cell - Unit Frames
+## Author: Vollmer
+## Version: @project-version@
+## X-Date: @project-date-iso@
+## X-License: MIT
+## X-Curse-Project-ID: 1085605
+## X-Wago-ID: ZKxqRdGk
+
+## Dependencies: Cell
+
+## Notes: Unitframes for our beloved Cell!
+
+Libs/LoadLibs_Vanilla.xml
+
+Locales/LoadLocales.xml
+Core/Init.lua
+Core/Events.lua
+
+Data/Constants.lua
+Util/Utils.lua
+Util/PixelPerfect.lua
+Data/Defaults.lua
+Data/Database.lua
+Data/DBUtil.lua
+Data/Revise.lua
+
+Util/Handler.lua
+Util/HideBlizzard.lua
+Util/HelpTips.lua
+
+Debug/DebugWindow.lua
+Debug/Debug.lua
+
+Core/SlashCommands.lua
+
+Menu/Builder.lua
+Menu/AuraFilterList.lua
+Menu/Menu.lua
+Menu/ImportExport.lua
+Menu/GeneralTab.lua
+Menu/UnitFramesTab.lua
+Menu/WidgetsTab.lua
+Menu/FaderTab.lua
+Menu/ColorTab.lua
+
+Widgets/Common.lua
+
+Widgets/Texts/BaseTextWidget.lua
+Widgets/Texts/CustomFormats.lua
+Widgets/Texts/NameText.lua
+Widgets/Texts/HealthText.lua
+Widgets/Texts/PowerText.lua
+Widgets/Texts/LevelText.lua
+Widgets/Texts/CustomText.lua
+
+Widgets/Bars/HealthBar.lua
+Widgets/Bars/PowerBar.lua
+Widgets/Bars/ShieldBar.lua
+Widgets/Bars/CastBar.lua
+Widgets/Bars/ClassBar.lua
+Widgets/Bars/HealAbsorb.lua
+
+Widgets/Icons/RaidIcon.lua
+Widgets/Icons/RoleIcon.lua
+Widgets/Icons/LeaderIcon.lua
+Widgets/Icons/CombatIcon.lua
+Widgets/Icons/ReadyCheckIcon.lua
+Widgets/Icons/RestingIcon.lua
+
+Widgets/Auras/Auras.lua
+Widgets/Auras/Updater.lua
+Widgets/Auras/Dispels.lua
+Widgets/Auras/Totems.lua
+
+Widgets/Misc/Fader.lua
+
+UnitFrames/UnitButton.xml
+UnitFrames/UnitButton.lua
+UnitFrames/OnLoad.lua
+UnitFrames/MenuOptions.lua
+UnitFrames/EditMode.lua
+
+API/Common.lua
+API/CustomAnchors.lua
+
+Core/OnLoad.lua

--- a/Libs/LoadLibs_Vanilla.xml
+++ b/Libs/LoadLibs_Vanilla.xml
@@ -1,0 +1,5 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/AddOns/Blizzard_SharedXML/UI.xsd">
+    <!-- externals -->
+    <Include file="!BlizzPolyfill\!BlizzPolyfill.xml"/>
+</Ui>


### PR DESCRIPTION
First time writing an addon that's meant to be plugged in as a lib somewhere, so I hope this works out.
Referenced other addons to see how they do it.

[!BlizzPolyfill](https://github.com/inyawfaze/BlizzPolyfill) adds different functions which are directly taken from the `BlizzardInterfaceCode`. Some serve as stubs so no Lua errors are thrown (e.g. `pings`), others just add functions to tables that are only partially available in Era (e.g. `AuraUtil`). I needed to DIY some functions, since these are not available via the `BlizzardInterfaceCode` (e.g. `GameTooltip:SetUnitBuffByAuraInstanceID`).

Added the `LoadLibs` functionality parallel to how Cell does it.

Steps to integrate this into Cell_UnitFrames:
 - Add seperate _Vanilla.toc
 - Include new LoadLibs via new .toc
 - LoadLibs includes the external !BlizzPolyfill lib
 - Reference the external !BlizzPolyfill lib in .pkgmeta for automated inclusion in the distributed .zip file

Worked this out locally with symlinks, hope the automatic inclusion via .pkgmeta works out. 😅 

Features that work with this:
 - EditMode
 - Frames
   - Player
   - Target
   - Pet
   - TargetTarget
 - Frame Features:
   - Name Text
   - Health Text
   - Power Text
   - Level Text
   - Custom Text
   - Raid Icon
   - Leader Icon
   - Combat Icon
   - Ready Check Icon
   - Resting Icon
   - Buffs
   - Debuffs
   - Dispels 
     - only tested with poisons
   - Totems

Features that do not work/are unsupported on Classic Era:
 - Frames 
   - Boss
   - Focus
 - Frame Features
   - Shield Bar
     - _maybe_ could be fixed by implementing `LibHealComm`
   - Class Bar
   - Heal Absorb
   - Role Icon 
     - always shows DPS, I think this info was queried from Cell's LibGroupInfo, which isn't loaded in Classic
     - can be fixed rather easily

Features that are not thoroughly tested, but seem to work/not break other stuff/not throw errors:
 - Layouts
 - Disabling Blizzard Frames
   - Some were already hidden before I checked their checkbox, but they _are_ hidden
 - Frame Features
   - Click Casting
 - Colors