### PR TITLE
 [Feature] Implement option to create Dummy Anchors to help transition from other UF addons

### DIFF
--- a/Cell_UnitFrames.toc
+++ b/Cell_UnitFrames.toc
@@ -29,6 +29,7 @@ Data/Revise.lua
 Util/Handler.lua
 Util/HideBlizzard.lua
 Util/HelpTips.lua
+Util/Compat.lua
 
 Debug/DebugWindow.lua
 Debug/Debug.lua

--- a/Core/Init.lua
+++ b/Core/Init.lua
@@ -26,6 +26,8 @@ CUF.Builder = {}
 CUF.API = {}
 ---@class CUF.PixelPerfect
 CUF.PixelPerfect = {}
+---@class CUF.Compat
+CUF.Compat = {}
 
 ---@class CUF.vars
 ---@field selectedLayout string

--- a/Core/OnLoad.lua
+++ b/Core/OnLoad.lua
@@ -37,6 +37,8 @@ local function OnCellInitialUpdateLayout(_layout)
     CUF.uFuncs:InitUnitButtons()
     CUF:Fire("UpdateUnitButtons")
 
+    CUF.Compat:InitDummyAnchors()
+
     -- Register callbacks
     Cell:RegisterCallback("UpdateIndicators", "CUF_UpdateIndicators",
         function(layout) CUF:Fire("UpdateWidget", layout) end)

--- a/Data/DBUtil.lua
+++ b/Data/DBUtil.lua
@@ -42,6 +42,13 @@ function DB.InitDB()
     ---@type Defaults.BlizzardFrames
     CUF_DB.blizzardFrames = CUF_DB.blizzardFrames or Util:CopyDeep(Defaults.BlizzardFrames)
 
+    ---@class CUF.database.dummyAnchors.anchor
+    ---@field dummyName string
+    ---@field enabled boolean
+
+    ---@type table<string, CUF.database.dummyAnchors.anchor>
+    CUF_DB.dummyAnchors = CUF_DB.dummyAnchors or {}
+
     DB.CreateAutomaticBackup()
     DB:Revise()
 

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -64,6 +64,12 @@ L.RestoreBackupPopup = [[Restore this backup?
 L.ColorTypeTooltip = [[|cFFFFD700Cell|r - Uses the appearance settings from |cFFFFD700Cell|r.
 Custom Unit Frame colors can be changed in the |cFFFFD700Colors|r tab.]]
 
+L.CUFFrameName = "CUF Frame Name"
+L.DummyAnchorName = "Dummy Anchor Name"
+L.DummyAnchors = "Dummy Anchors"
+L.DummyAnchorsTooltip = [[Create custom-named anchors to match other addons.
+Useful for integrating with existing UI elements like WeakAuras.]]
+
 -- Units
 L.targettarget = "TargetTarget"
 L.player = "Player"

--- a/Util/Compat.lua
+++ b/Util/Compat.lua
@@ -1,0 +1,33 @@
+---@class CUF
+local CUF = select(2, ...)
+
+---@class CUF.Compat
+local Compat = CUF.Compat
+
+---@param name string
+---@param parent string
+function Compat:CreateDummyAnchor(name, parent)
+    if type(name) ~= "string" then
+        CUF:Warn("Invalid dummy anchor name:", "'" .. name .. "'")
+        return
+    end
+
+    if type(parent) ~= "string" then return end
+    if not _G[parent] then return end
+
+    if _G[name] then
+        CUF:Warn("Frame with name:", "'" .. name .. "'", "already exists! Unable to create dummy anchor.")
+        return
+    end
+
+    local dummy = CreateFrame("Frame", name, _G[parent])
+    dummy:SetAllPoints(_G[parent])
+end
+
+function Compat:InitDummyAnchors()
+    for parent, anchor in pairs(CUF_DB.dummyAnchors) do
+        if anchor.enabled then
+            Compat:CreateDummyAnchor(anchor.dummyName, parent)
+        end
+    end
+end


### PR DESCRIPTION
Implements the option to create Dummy Anchors for Unit Frames to help transition from other UF addons, without having to change anchors in various WeakAuras.