### PR TITLE
[Feature] Add "Appearance" subtab to Unit Frames with options to overwrite textures

### DIFF
--- a/Cell_UnitFrames.toc
+++ b/Cell_UnitFrames.toc
@@ -46,6 +46,7 @@ Menu/GeneralTab.lua
 Menu/UnitFramesTab.lua
 Menu/WidgetsTab.lua
 Menu/FaderTab.lua
+Menu/AppearanceTab.lua
 Menu/ColorTab.lua
 Menu/VisibilityTab.lua
 

--- a/Data/Defaults.lua
+++ b/Data/Defaults.lua
@@ -985,6 +985,10 @@ Defaults.Widgets_Boss.castBar.spell.offsetX = 0
 ---@field healthBarColorType UnitButtonColorType
 ---@field healthLossColorType UnitButtonColorType
 ---@field visibility string
+---@field healthBarTexture string
+---@field useHealthBarTexture boolean
+---@field healthLossTexture string
+---@field useHealthLossTexture boolean
 
 ---@alias UnitLayoutTable table<Unit, UnitLayout>
 ---@type UnitLayoutTable
@@ -998,7 +1002,11 @@ Defaults.Layouts = {
         barOrientation = "horizontal",
         healthBarColorType = CUF.constants.UnitButtonColorType.CELL,
         healthLossColorType = CUF.constants.UnitButtonColorType.CUSTOM,
-        visibility = "[petbattle] hide;show"
+        visibility = "[petbattle] hide;show",
+        healthBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthBarTexture = false,
+        healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthLossTexture = false,
     },
     target = {
         enabled = false,
@@ -1031,7 +1039,11 @@ Defaults.Layouts = {
         barOrientation = "horizontal",
         healthBarColorType = CUF.constants.UnitButtonColorType.CELL,
         healthLossColorType = CUF.constants.UnitButtonColorType.CUSTOM,
-        visibility = ""
+        visibility = "",
+        healthBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthBarTexture = false,
+        healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthLossTexture = false,
     },
     focus = {
         enabled = false,
@@ -1071,7 +1083,11 @@ Defaults.Layouts = {
         barOrientation = "horizontal",
         healthBarColorType = CUF.constants.UnitButtonColorType.CELL,
         healthLossColorType = CUF.constants.UnitButtonColorType.CUSTOM,
-        visibility = ""
+        visibility = "",
+        healthBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthBarTexture = false,
+        healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthLossTexture = false,
     },
     targettarget = {
         enabled = false,
@@ -1101,7 +1117,11 @@ Defaults.Layouts = {
         alwaysUpdate = true,
         healthBarColorType = CUF.constants.UnitButtonColorType.CELL,
         healthLossColorType = CUF.constants.UnitButtonColorType.CUSTOM,
-        visibility = ""
+        visibility = "",
+        healthBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthBarTexture = false,
+        healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthLossTexture = false,
     },
     pet = {
         enabled = false,
@@ -1137,7 +1157,11 @@ Defaults.Layouts = {
         barOrientation = "horizontal",
         healthBarColorType = CUF.constants.UnitButtonColorType.CELL,
         healthLossColorType = CUF.constants.UnitButtonColorType.CUSTOM,
-        visibility = ""
+        visibility = "",
+        healthBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthBarTexture = false,
+        healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthLossTexture = false,
     },
     boss = {
         enabled = false,
@@ -1165,7 +1189,11 @@ Defaults.Layouts = {
         },
         healthBarColorType = CUF.constants.UnitButtonColorType.CELL,
         healthLossColorType = CUF.constants.UnitButtonColorType.CUSTOM,
-        visibility = ""
+        visibility = "",
+        healthBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthBarTexture = false,
+        healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        useHealthLossTexture = false,
     }
 }
 

--- a/Data/Defaults.lua
+++ b/Data/Defaults.lua
@@ -989,6 +989,10 @@ Defaults.Widgets_Boss.castBar.spell.offsetX = 0
 ---@field useHealthBarTexture boolean
 ---@field healthLossTexture string
 ---@field useHealthLossTexture boolean
+---@field powerBarTexture string
+---@field usePowerBarTexture boolean
+---@field powerLossTexture string
+---@field usePowerLossTexture boolean
 
 ---@alias UnitLayoutTable table<Unit, UnitLayout>
 ---@type UnitLayoutTable
@@ -1007,6 +1011,10 @@ Defaults.Layouts = {
         useHealthBarTexture = false,
         healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
         useHealthLossTexture = false,
+        powerBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerBarTexture = false,
+        powerLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerLossTexture = false,
     },
     target = {
         enabled = false,
@@ -1044,6 +1052,10 @@ Defaults.Layouts = {
         useHealthBarTexture = false,
         healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
         useHealthLossTexture = false,
+        powerBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerBarTexture = false,
+        powerLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerLossTexture = false,
     },
     focus = {
         enabled = false,
@@ -1088,6 +1100,10 @@ Defaults.Layouts = {
         useHealthBarTexture = false,
         healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
         useHealthLossTexture = false,
+        powerBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerBarTexture = false,
+        powerLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerLossTexture = false,
     },
     targettarget = {
         enabled = false,
@@ -1122,6 +1138,10 @@ Defaults.Layouts = {
         useHealthBarTexture = false,
         healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
         useHealthLossTexture = false,
+        powerBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerBarTexture = false,
+        powerLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerLossTexture = false,
     },
     pet = {
         enabled = false,
@@ -1162,6 +1182,10 @@ Defaults.Layouts = {
         useHealthBarTexture = false,
         healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
         useHealthLossTexture = false,
+        powerBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerBarTexture = false,
+        powerLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerLossTexture = false,
     },
     boss = {
         enabled = false,
@@ -1194,6 +1218,10 @@ Defaults.Layouts = {
         useHealthBarTexture = false,
         healthLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
         useHealthLossTexture = false,
+        powerBarTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerBarTexture = false,
+        powerLossTexture = "Interface\\AddOns\\Cell\\Media\\statusbar.tga",
+        usePowerLossTexture = false,
     }
 }
 

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -244,6 +244,11 @@ L.FadeInTimer = "Fade In Timer"
 L.FadeOutTimer = "Fade Out Timer"
 L.Enrage = "Enrage"
 L.overHeal = "Over Heal"
+L.healthBarTexture = "Health Bar Texture"
+L.healthLossTexture = "Health Loss Texture"
+L.powerBarTexture = "Power Bar Texture"
+L.powerLossTexture = "Power Loss Texture"
+L.TextureOverwriteTooltip = "Enable to overwrite texture set in Cell"
 
 -- Custom Formats
 L.ValidTags = "Valid Tags"

--- a/Menu/AppearanceTab.lua
+++ b/Menu/AppearanceTab.lua
@@ -16,7 +16,7 @@ local unitFramesTab = Menu.unitFramesTab
 ---@class AppearanceTab: Menu.Tab
 local AppearanceTab = {}
 AppearanceTab.id = "Appearance"
-AppearanceTab.height = 300
+AppearanceTab.height = 180
 AppearanceTab.paneHeight = 17
 
 unitFramesTab:AddTab(AppearanceTab)
@@ -91,7 +91,7 @@ function AppearanceTab:Create()
     self.unit = const.UNIT.PLAYER
 
     local section = CUF:CreateFrame("CUF_Menu_UnitFrame_Appearance_Section", self.window, sectionWidth - 10,
-        200, false, true)
+        self.height - 25, false, true)
     section:SetPoint("TOPLEFT", self.window, "TOPLEFT", 5, -5)
 
     ---@type CellDropdown
@@ -201,7 +201,7 @@ function AppearanceTab:Create()
     healthTextureDropdown:SetItems(textureDropdownItems)
 
     ---@type CellCheckButton
-    local healthTextureEnable = Cell.CreateCheckButton(section, L["Enabled"], function(checked, cb)
+    local healthTextureEnable = Cell.CreateCheckButton(section, "", function(checked, cb)
         DB.SelectedLayoutTable()[self.unit].useHealthBarTexture = checked
         healthTextureDropdown:SetEnabled(checked)
         CUF:Fire("UpdateAppearance", "texture")
@@ -229,7 +229,7 @@ function AppearanceTab:Create()
     healthLossTextureDropdown:SetItems(textureDropdownItems)
 
     ---@type CellCheckButton
-    local healthLossTextureEnable = Cell.CreateCheckButton(section, L["Enabled"], function(checked, cb)
+    local healthLossTextureEnable = Cell.CreateCheckButton(section, "", function(checked, cb)
         DB.SelectedLayoutTable()[self.unit].useHealthLossTexture = checked
         healthLossTextureDropdown:SetEnabled(checked)
         CUF:Fire("UpdateAppearance", "texture")

--- a/Menu/AppearanceTab.lua
+++ b/Menu/AppearanceTab.lua
@@ -216,7 +216,7 @@ function AppearanceTab:Create()
         DB.SelectedLayoutTable()[self.unit].useHealthBarTexture = checked
         healthTextureDropdown:SetEnabled(checked)
         CUF:Fire("UpdateAppearance", "texture")
-    end)
+    end, L.TextureOverwriteTooltip)
     healthTextureEnable:SetPoint("LEFT", healthTextureDropdown, "RIGHT", 5, 0)
     self.healthTextureEnable = healthTextureEnable
 
@@ -242,7 +242,7 @@ function AppearanceTab:Create()
         DB.SelectedLayoutTable()[self.unit].useHealthLossTexture = checked
         healthLossTextureDropdown:SetEnabled(checked)
         CUF:Fire("UpdateAppearance", "texture")
-    end)
+    end, L.TextureOverwriteTooltip)
     healthLossTextureEnable:SetPoint("LEFT", healthLossTextureDropdown, "RIGHT", 5, 0)
     self.healthLossTextureEnable = healthLossTextureEnable
 
@@ -272,7 +272,7 @@ function AppearanceTab:Create()
         DB.SelectedLayoutTable()[self.unit].usePowerBarTexture = checked
         powerBarTextureDropdown:SetEnabled(checked)
         CUF:Fire("UpdateAppearance", "texture")
-    end)
+    end, L.TextureOverwriteTooltip)
     powerBarTextureEnable:SetPoint("LEFT", powerBarTextureDropdown, "RIGHT", 5, 0)
     self.powerBarTextureEnable = powerBarTextureEnable
 
@@ -298,7 +298,7 @@ function AppearanceTab:Create()
         DB.SelectedLayoutTable()[self.unit].usePowerLossTexture = checked
         powerLossTextureDropdown:SetEnabled(checked)
         CUF:Fire("UpdateAppearance", "texture")
-    end)
+    end, L.TextureOverwriteTooltip)
     powerLossTextureEnable:SetPoint("LEFT", powerLossTextureDropdown, "RIGHT", 5, 0)
     self.powerLossTextureEnable = powerLossTextureEnable
 end

--- a/Menu/AppearanceTab.lua
+++ b/Menu/AppearanceTab.lua
@@ -16,7 +16,7 @@ local unitFramesTab = Menu.unitFramesTab
 ---@class AppearanceTab: Menu.Tab
 local AppearanceTab = {}
 AppearanceTab.id = "Appearance"
-AppearanceTab.height = 180
+AppearanceTab.height = 280
 AppearanceTab.paneHeight = 17
 
 unitFramesTab:AddTab(AppearanceTab)
@@ -73,6 +73,15 @@ function AppearanceTab.LoadUnit(unit)
         layout.healthLossTexture)
     AppearanceTab.healthLossTextureDropdown:SetEnabled(layout.useHealthLossTexture)
     AppearanceTab.healthLossTextureEnable:SetChecked(layout.useHealthLossTexture)
+
+    AppearanceTab.powerTextureDropdown:SetSelected(Util.textureToName[layout.powerBarTexture], layout.powerBarTexture)
+    AppearanceTab.powerTextureDropdown:SetEnabled(layout.usePowerBarTexture)
+    AppearanceTab.powerBarTextureEnable:SetChecked(layout.usePowerBarTexture)
+
+    AppearanceTab.powerLossTextureDropdown:SetSelected(Util.textureToName[layout.powerLossTexture],
+        layout.powerLossTexture)
+    AppearanceTab.powerLossTextureDropdown:SetEnabled(layout.usePowerLossTexture)
+    AppearanceTab.powerLossTextureEnable:SetChecked(layout.usePowerLossTexture)
 end
 
 CUF:RegisterCallback("LoadPageDB", "AppearanceTab_LoadUnit", AppearanceTab.LoadUnit)
@@ -181,15 +190,18 @@ function AppearanceTab:Create()
     CUF:SetTooltips(healthBarColorTypeDropdown, "ANCHOR_TOPLEFT", 0, 3, L["Health Bar Color"],
         L.ColorTypeTooltip)
 
+    --------------------------
+    --- Health Bar Texture ---
+    --------------------------
+
     ---@type CellDropdown
     local healthTextureDropdown = Cell.CreateDropdown(section, 200, "texture")
     self.healthTextureDropdown = healthTextureDropdown
     healthTextureDropdown:SetPoint("TOPLEFT", healthBarColorTypeDropdown, "BOTTOMLEFT", 0, -30)
     healthTextureDropdown:SetLabel(L.healthBarTexture)
 
-    local textureDropdownItems = {}
     for name, tex in pairs(Util:GetTextures()) do
-        table.insert(textureDropdownItems, {
+        healthTextureDropdown:AddItem({
             ["text"] = name,
             ["texture"] = tex,
             ["onClick"] = function()
@@ -198,7 +210,6 @@ function AppearanceTab:Create()
             end,
         })
     end
-    healthTextureDropdown:SetItems(textureDropdownItems)
 
     ---@type CellCheckButton
     local healthTextureEnable = Cell.CreateCheckButton(section, "", function(checked, cb)
@@ -215,9 +226,8 @@ function AppearanceTab:Create()
     healthLossTextureDropdown:SetPoint("TOPLEFT", healthTextureDropdown, "BOTTOMLEFT", 0, -30)
     healthLossTextureDropdown:SetLabel(L.healthLossTexture)
 
-    table.wipe(textureDropdownItems)
     for name, tex in pairs(Util:GetTextures()) do
-        table.insert(textureDropdownItems, {
+        healthLossTextureDropdown:AddItem({
             ["text"] = name,
             ["texture"] = tex,
             ["onClick"] = function()
@@ -226,7 +236,6 @@ function AppearanceTab:Create()
             end,
         })
     end
-    healthLossTextureDropdown:SetItems(textureDropdownItems)
 
     ---@type CellCheckButton
     local healthLossTextureEnable = Cell.CreateCheckButton(section, "", function(checked, cb)
@@ -236,4 +245,60 @@ function AppearanceTab:Create()
     end)
     healthLossTextureEnable:SetPoint("LEFT", healthLossTextureDropdown, "RIGHT", 5, 0)
     self.healthLossTextureEnable = healthLossTextureEnable
+
+    --------------------------
+    --- Power Bar Texture ---
+    --------------------------
+
+    ---@type CellDropdown
+    local powerBarTextureDropdown = Cell.CreateDropdown(section, 200, "texture")
+    self.powerTextureDropdown = powerBarTextureDropdown
+    powerBarTextureDropdown:SetPoint("TOPLEFT", healthLossTextureDropdown, "BOTTOMLEFT", 0, -30)
+    powerBarTextureDropdown:SetLabel(L.powerBarTexture)
+
+    for name, tex in pairs(Util:GetTextures()) do
+        powerBarTextureDropdown:AddItem({
+            ["text"] = name,
+            ["texture"] = tex,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].powerBarTexture = tex
+                CUF:Fire("UpdateAppearance", "texture")
+            end,
+        })
+    end
+
+    ---@type CellCheckButton
+    local powerBarTextureEnable = Cell.CreateCheckButton(section, "", function(checked, cb)
+        DB.SelectedLayoutTable()[self.unit].usePowerBarTexture = checked
+        powerBarTextureDropdown:SetEnabled(checked)
+        CUF:Fire("UpdateAppearance", "texture")
+    end)
+    powerBarTextureEnable:SetPoint("LEFT", powerBarTextureDropdown, "RIGHT", 5, 0)
+    self.powerBarTextureEnable = powerBarTextureEnable
+
+    ---@type CellDropdown
+    local powerLossTextureDropdown = Cell.CreateDropdown(section, 200, "texture")
+    self.powerLossTextureDropdown = powerLossTextureDropdown
+    powerLossTextureDropdown:SetPoint("TOPLEFT", powerBarTextureDropdown, "BOTTOMLEFT", 0, -30)
+    powerLossTextureDropdown:SetLabel(L.powerLossTexture)
+
+    for name, tex in pairs(Util:GetTextures()) do
+        powerLossTextureDropdown:AddItem({
+            ["text"] = name,
+            ["texture"] = tex,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].powerLossTexture = tex
+                CUF:Fire("UpdateAppearance", "texture")
+            end,
+        })
+    end
+
+    ---@type CellCheckButton
+    local powerLossTextureEnable = Cell.CreateCheckButton(section, "", function(checked, cb)
+        DB.SelectedLayoutTable()[self.unit].usePowerLossTexture = checked
+        powerLossTextureDropdown:SetEnabled(checked)
+        CUF:Fire("UpdateAppearance", "texture")
+    end)
+    powerLossTextureEnable:SetPoint("LEFT", powerLossTextureDropdown, "RIGHT", 5, 0)
+    self.powerLossTextureEnable = powerLossTextureEnable
 end

--- a/Menu/AppearanceTab.lua
+++ b/Menu/AppearanceTab.lua
@@ -1,0 +1,239 @@
+---@class CUF
+local CUF = select(2, ...)
+
+local Cell = CUF.Cell
+local L = CUF.L
+
+local DB = CUF.DB
+local const = CUF.constants
+local Util = CUF.Util
+
+---@class CUF.Menu
+local Menu = CUF.Menu
+
+local unitFramesTab = Menu.unitFramesTab
+
+---@class AppearanceTab: Menu.Tab
+local AppearanceTab = {}
+AppearanceTab.id = "Appearance"
+AppearanceTab.height = 300
+AppearanceTab.paneHeight = 17
+
+unitFramesTab:AddTab(AppearanceTab)
+
+-------------------------------------------------
+-- MARK: Show/Hide
+-------------------------------------------------
+
+---@param unit Unit
+function AppearanceTab:ShowTab(unit)
+    if not self.window then
+        self:Create()
+
+        self.window:Show()
+        self.LoadUnit(unit)
+        return
+    end
+
+    self.window:Show()
+    self.LoadUnit(unit)
+end
+
+function AppearanceTab:HideTab()
+    if not self.window or not self.window:IsShown() then return end
+    self.window:Hide()
+end
+
+function AppearanceTab:IsShown()
+    return self.window and self.window:IsShown()
+end
+
+---@param unit Unit
+function AppearanceTab.LoadUnit(unit)
+    if not AppearanceTab:IsShown() then return end
+    unit = unit or CUF.vars.selectedUnit
+
+    local layout = DB.SelectedLayoutTable()[unit]
+    if not layout then
+        CUF:Warn("[AppearanceTab] No layout for unit:", unit)
+        return
+    end
+    AppearanceTab.unit = unit
+
+    AppearanceTab.healthBarColorTypeDropdown:SetSelectedValue(layout.healthBarColorType)
+    AppearanceTab.healthLossColorTypeDropdown:SetSelectedValue(layout.healthLossColorType)
+    AppearanceTab.healthLossColorTypeDropdown:SetEnabled(layout.healthBarColorType ~=
+        CUF.constants.UnitButtonColorType.CELL)
+
+    AppearanceTab.healthTextureDropdown:SetSelected(Util.textureToName[layout.healthBarTexture], layout.healthBarTexture)
+    AppearanceTab.healthTextureDropdown:SetEnabled(layout.useHealthBarTexture)
+    AppearanceTab.healthTextureEnable:SetChecked(layout.useHealthBarTexture)
+
+    AppearanceTab.healthLossTextureDropdown:SetSelected(Util.textureToName[layout.healthLossTexture],
+        layout.healthLossTexture)
+    AppearanceTab.healthLossTextureDropdown:SetEnabled(layout.useHealthLossTexture)
+    AppearanceTab.healthLossTextureEnable:SetChecked(layout.useHealthLossTexture)
+end
+
+CUF:RegisterCallback("LoadPageDB", "AppearanceTab_LoadUnit", AppearanceTab.LoadUnit)
+
+-------------------------------------------------
+-- MARK: Create
+-------------------------------------------------
+
+function AppearanceTab:Create()
+    local sectionWidth = unitFramesTab.tabAnchor:GetWidth()
+
+    self.window = CUF:CreateFrame("CUF_Menu_UnitFrame_Appearance", unitFramesTab.window,
+        sectionWidth,
+        self.height, true)
+    self.window:SetPoint("TOPLEFT", unitFramesTab.tabAnchor, "TOPLEFT")
+    self.unit = const.UNIT.PLAYER
+
+    local section = CUF:CreateFrame("CUF_Menu_UnitFrame_Appearance_Section", self.window, sectionWidth - 10,
+        200, false, true)
+    section:SetPoint("TOPLEFT", self.window, "TOPLEFT", 5, -5)
+
+    ---@type CellDropdown
+    local healthBarColorTypeDropdown = Cell.CreateDropdown(section, 141)
+    self.healthBarColorTypeDropdown = healthBarColorTypeDropdown
+    healthBarColorTypeDropdown:SetPoint("TOPLEFT", 10, -25)
+    healthBarColorTypeDropdown:SetLabel(L["Health Bar Color"])
+    healthBarColorTypeDropdown:SetItems({
+        {
+            ["text"] = L["Cell"],
+            ["value"] = CUF.constants.UnitButtonColorType.CELL,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthBarColorType = CUF.constants.UnitButtonColorType
+                    .CELL
+                CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", self.unit)
+                self.healthLossColorTypeDropdown:SetEnabled(false)
+            end,
+        },
+        {
+            ["text"] = L["Class Color"],
+            ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthBarColorType = CUF.constants.UnitButtonColorType
+                    .CLASS_COLOR
+                CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", self.unit)
+                self.healthLossColorTypeDropdown:SetEnabled(true)
+            end,
+        },
+        {
+            ["text"] = L["Class Color (dark)"],
+            ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR_DARK,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthBarColorType = CUF.constants.UnitButtonColorType
+                    .CLASS_COLOR_DARK
+                CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", self.unit)
+                self.healthLossColorTypeDropdown:SetEnabled(true)
+            end,
+        },
+        {
+            ["text"] = L["Custom Color"],
+            ["value"] = CUF.constants.UnitButtonColorType.CUSTOM,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthBarColorType = CUF.constants.UnitButtonColorType
+                    .CUSTOM
+                CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", self.unit)
+                self.healthLossColorTypeDropdown:SetEnabled(true)
+            end,
+        },
+    })
+
+    ---@type CellDropdown
+    local healthLossColorTypeDropdown = Cell.CreateDropdown(section, 141)
+    self.healthLossColorTypeDropdown = healthLossColorTypeDropdown
+    healthLossColorTypeDropdown:SetLabel(L["Health Loss Color"])
+    healthLossColorTypeDropdown:SetItems({
+        {
+            ["text"] = L["Class Color"],
+            ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthLossColorType = CUF.constants.UnitButtonColorType
+                    .CLASS_COLOR
+                CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", self.unit)
+            end,
+        },
+        {
+            ["text"] = L["Class Color (dark)"],
+            ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR_DARK,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthLossColorType = CUF.constants.UnitButtonColorType
+                    .CLASS_COLOR_DARK
+                CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", self.unit)
+            end,
+        },
+        {
+            ["text"] = L["Custom Color"],
+            ["value"] = CUF.constants.UnitButtonColorType.CUSTOM,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthLossColorType = CUF.constants.UnitButtonColorType
+                    .CUSTOM
+                CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", self.unit)
+            end,
+        },
+    })
+    healthLossColorTypeDropdown:SetPoint("TOPLEFT", healthBarColorTypeDropdown, "TOPRIGHT",
+        5, 0)
+
+    CUF:SetTooltips(healthBarColorTypeDropdown, "ANCHOR_TOPLEFT", 0, 3, L["Health Bar Color"],
+        L.ColorTypeTooltip)
+
+    ---@type CellDropdown
+    local healthTextureDropdown = Cell.CreateDropdown(section, 200, "texture")
+    self.healthTextureDropdown = healthTextureDropdown
+    healthTextureDropdown:SetPoint("TOPLEFT", healthBarColorTypeDropdown, "BOTTOMLEFT", 0, -30)
+    healthTextureDropdown:SetLabel(L.healthBarTexture)
+
+    local textureDropdownItems = {}
+    for name, tex in pairs(Util:GetTextures()) do
+        table.insert(textureDropdownItems, {
+            ["text"] = name,
+            ["texture"] = tex,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthBarTexture = tex
+                CUF:Fire("UpdateAppearance", "texture")
+            end,
+        })
+    end
+    healthTextureDropdown:SetItems(textureDropdownItems)
+
+    ---@type CellCheckButton
+    local healthTextureEnable = Cell.CreateCheckButton(section, L["Enabled"], function(checked, cb)
+        DB.SelectedLayoutTable()[self.unit].useHealthBarTexture = checked
+        healthTextureDropdown:SetEnabled(checked)
+        CUF:Fire("UpdateAppearance", "texture")
+    end)
+    healthTextureEnable:SetPoint("LEFT", healthTextureDropdown, "RIGHT", 5, 0)
+    self.healthTextureEnable = healthTextureEnable
+
+    ---@type CellDropdown
+    local healthLossTextureDropdown = Cell.CreateDropdown(section, 200, "texture")
+    self.healthLossTextureDropdown = healthLossTextureDropdown
+    healthLossTextureDropdown:SetPoint("TOPLEFT", healthTextureDropdown, "BOTTOMLEFT", 0, -30)
+    healthLossTextureDropdown:SetLabel(L.healthLossTexture)
+
+    table.wipe(textureDropdownItems)
+    for name, tex in pairs(Util:GetTextures()) do
+        table.insert(textureDropdownItems, {
+            ["text"] = name,
+            ["texture"] = tex,
+            ["onClick"] = function()
+                DB.SelectedLayoutTable()[self.unit].healthLossTexture = tex
+                CUF:Fire("UpdateAppearance", "texture")
+            end,
+        })
+    end
+    healthLossTextureDropdown:SetItems(textureDropdownItems)
+
+    ---@type CellCheckButton
+    local healthLossTextureEnable = Cell.CreateCheckButton(section, L["Enabled"], function(checked, cb)
+        DB.SelectedLayoutTable()[self.unit].useHealthLossTexture = checked
+        healthLossTextureDropdown:SetEnabled(checked)
+        CUF:Fire("UpdateAppearance", "texture")
+    end)
+    healthLossTextureEnable:SetPoint("LEFT", healthLossTextureDropdown, "RIGHT", 5, 0)
+    self.healthLossTextureEnable = healthLossTextureEnable
+end

--- a/Menu/UnitFramesTab.lua
+++ b/Menu/UnitFramesTab.lua
@@ -21,7 +21,7 @@ unitFramesTab.id = "unitFramesTab"
 unitFramesTab.unitPages = {}
 unitFramesTab.unitsToAdd = {}
 unitFramesTab.unitPageButtons = {}
-unitFramesTab.unitHeight = 200
+unitFramesTab.unitHeight = 160
 unitFramesTab.paneHeight = 17
 
 Menu.unitFramesTab = unitFramesTab

--- a/UnitFrames/MenuOptions.lua
+++ b/UnitFrames/MenuOptions.lua
@@ -73,11 +73,6 @@ local function AddLoadPageDB(unitPage)
             unitPage.alwaysUpdateCB:SetChecked(pageDB.alwaysUpdate)
         end
 
-        unitPage.healthBarColorTypeDropdown:SetSelectedValue(pageDB.healthBarColorType)
-        unitPage.healthLossColorTypeDropdown:SetSelectedValue(pageDB.healthLossColorType)
-        unitPage.healthLossColorTypeDropdown:SetEnabled(pageDB.healthBarColorType ~=
-            CUF.constants.UnitButtonColorType.CELL)
-
         unitPage.enabledCB:SetChecked(pageDB.enabled)
     end
     CUF:RegisterCallback("LoadPageDB", "Units_" .. unitPage.id .. "_LoadPageDB", LoadPageDB)
@@ -198,92 +193,6 @@ local function AddUnitsToMenu()
                 end)
                 unitPage.heightSlider:SetPoint("TOPLEFT", unitPage.widthSlider, 0, -55)
 
-                ---@type CellDropdown
-                unitPage.healthBarColorTypeDropdown = Cell.CreateDropdown(unitPage.frame, 141)
-                unitPage.healthBarColorTypeDropdown:SetPoint("TOPLEFT", unitPage.heightSlider, "TOPRIGHT", 30, 0)
-                unitPage.healthBarColorTypeDropdown:SetLabel(L["Health Bar Color"])
-                unitPage.healthBarColorTypeDropdown:SetItems({
-                    {
-                        ["text"] = L["Cell"],
-                        ["value"] = CUF.constants.UnitButtonColorType.CELL,
-                        ["onClick"] = function()
-                            CUF.DB.SelectedLayoutTable()[unit].healthBarColorType = CUF.constants.UnitButtonColorType
-                                .CELL
-                            CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", unit)
-                            unitPage.healthLossColorTypeDropdown:SetEnabled(false)
-                        end,
-                    },
-                    {
-                        ["text"] = L["Class Color"],
-                        ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR,
-                        ["onClick"] = function()
-                            CUF.DB.SelectedLayoutTable()[unit].healthBarColorType = CUF.constants.UnitButtonColorType
-                                .CLASS_COLOR
-                            CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", unit)
-                            unitPage.healthLossColorTypeDropdown:SetEnabled(true)
-                        end,
-                    },
-                    {
-                        ["text"] = L["Class Color (dark)"],
-                        ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR_DARK,
-                        ["onClick"] = function()
-                            CUF.DB.SelectedLayoutTable()[unit].healthBarColorType = CUF.constants.UnitButtonColorType
-                                .CLASS_COLOR_DARK
-                            CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", unit)
-                            unitPage.healthLossColorTypeDropdown:SetEnabled(true)
-                        end,
-                    },
-                    {
-                        ["text"] = L["Custom Color"],
-                        ["value"] = CUF.constants.UnitButtonColorType.CUSTOM,
-                        ["onClick"] = function()
-                            CUF.DB.SelectedLayoutTable()[unit].healthBarColorType = CUF.constants.UnitButtonColorType
-                                .CUSTOM
-                            CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", unit)
-                            unitPage.healthLossColorTypeDropdown:SetEnabled(true)
-                        end,
-                    },
-                })
-
-                ---@type CellDropdown
-                unitPage.healthLossColorTypeDropdown = Cell.CreateDropdown(unitPage.frame, 141)
-                unitPage.healthLossColorTypeDropdown:SetPoint("TOPLEFT", unitPage.heightSlider, 0, -55)
-                unitPage.healthLossColorTypeDropdown:SetLabel(L["Health Loss Color"])
-                unitPage.healthLossColorTypeDropdown:SetItems({
-                    {
-                        ["text"] = L["Class Color"],
-                        ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR,
-                        ["onClick"] = function()
-                            CUF.DB.SelectedLayoutTable()[unit].healthLossColorType = CUF.constants.UnitButtonColorType
-                                .CLASS_COLOR
-                            CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", unit)
-                        end,
-                    },
-                    {
-                        ["text"] = L["Class Color (dark)"],
-                        ["value"] = CUF.constants.UnitButtonColorType.CLASS_COLOR_DARK,
-                        ["onClick"] = function()
-                            CUF.DB.SelectedLayoutTable()[unit].healthLossColorType = CUF.constants.UnitButtonColorType
-                                .CLASS_COLOR_DARK
-                            CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", unit)
-                        end,
-                    },
-                    {
-                        ["text"] = L["Custom Color"],
-                        ["value"] = CUF.constants.UnitButtonColorType.CUSTOM,
-                        ["onClick"] = function()
-                            CUF.DB.SelectedLayoutTable()[unit].healthLossColorType = CUF.constants.UnitButtonColorType
-                                .CUSTOM
-                            CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "colorType", unit)
-                        end,
-                    },
-                })
-                unitPage.healthLossColorTypeDropdown:SetPoint("TOPLEFT", unitPage.healthBarColorTypeDropdown, "TOPRIGHT",
-                    5, 0)
-
-                CUF:SetTooltips(unitPage.healthBarColorTypeDropdown, "ANCHOR_TOPLEFT", 0, 3, L["Health Bar Color"],
-                    L.ColorTypeTooltip)
-
                 if unit == "boss" then
                     ---@type CellSlider
                     unitPage.spacingSlider = Cell.CreateSlider(L["Spacing"], unitPage.frame, 0, 100, 117, 1,
@@ -293,12 +202,12 @@ local function AddUnitsToMenu()
                                 CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "spacing", unit)
                             end
                         end)
-                    unitPage.spacingSlider:SetPoint("TOPLEFT", unitPage.heightSlider, "BOTTOMLEFT", 0, -35)
+                    unitPage.spacingSlider:SetPoint("LEFT", unitPage.heightSlider, "RIGHT", 25, 0)
 
                     ---@type CellDropdown
                     unitPage.growthDirectionDropdown = Cell.CreateDropdown(unitPage.frame, 141)
                     unitPage.growthDirectionDropdown:SetPoint("TOPLEFT", unitPage.spacingSlider, "TOPRIGHT",
-                        30, 0)
+                        25, 0)
                     unitPage.growthDirectionDropdown:SetLabel(L.GrowthDirection)
 
                     for _, orientation in pairs(CUF.constants.GROWTH_ORIENTATION) do
@@ -331,7 +240,7 @@ local function AddUnitsToMenu()
                                     CUF:Fire("UpdateLayout", CUF.vars.selectedLayout, "alwaysUpdate", unit)
                                 end
                             end, L.AlwaysUpdate, string.format(L.AlwaysUpdateUnitFrameTooltip, "0.25"))
-                        unitPage.alwaysUpdateCB:SetPoint("TOPLEFT", unitPage.heightSlider, 0, -30)
+                        unitPage.alwaysUpdateCB:SetPoint("LEFT", unitPage.heightSlider, "RIGHT", 25, 0)
                     end
                 end
 

--- a/Widgets/Bars/HealthBar.lua
+++ b/Widgets/Bars/HealthBar.lua
@@ -170,8 +170,18 @@ end
 
 ---@param button CUFUnitButton
 function U:UnitFrame_UpdateHealthTexture(button)
-    button.widgets.healthBar:SetStatusBarTexture(F.GetBarTexture())
-    button.widgets.healthBarLoss:SetTexture(F.GetBarTexture())
+    local layout = DB.SelectedLayoutTable()[button._baseUnit]
+    if layout.useHealthBarTexture then
+        button.widgets.healthBar:SetStatusBarTexture(layout.healthBarTexture)
+    else
+        button.widgets.healthBar:SetStatusBarTexture(F.GetBarTexture())
+    end
+
+    if layout.useHealthLossTexture then
+        button.widgets.healthBarLoss:SetTexture(layout.healthLossTexture)
+    else
+        button.widgets.healthBarLoss:SetTexture(F.GetBarTexture())
+    end
 end
 
 ---@param button CUFUnitButton

--- a/Widgets/Bars/PowerBar.lua
+++ b/Widgets/Bars/PowerBar.lua
@@ -372,8 +372,18 @@ end
 
 ---@param button CUFUnitButton
 function U:UnitFrame_UpdatePowerTexture(button)
-    button.widgets.powerBar:SetStatusBarTexture(F.GetBarTexture())
-    button.widgets.powerBar.bg:SetTexture(F.GetBarTexture())
+    local layout = DB.SelectedLayoutTable()[button._baseUnit]
+    if layout.usePowerBarTexture then
+        button.widgets.powerBar:SetStatusBarTexture(layout.powerBarTexture)
+    else
+        button.widgets.powerBar:SetStatusBarTexture(F.GetBarTexture())
+    end
+
+    if layout.usePowerLossTexture then
+        button.widgets.powerBar.bg:SetTexture(layout.powerLossTexture)
+    else
+        button.widgets.powerBar.bg:SetTexture(F.GetBarTexture())
+    end
 end
 
 ---@param self PowerBarWidget


### PR DESCRIPTION
Implements #211.
Adds a new subtab "Appearance" for unit frames.
Moves the Health Bar/Loss color options to new subtab.

Adds texture options for Health Bar/Loss & Power Bar/Loss.