### PR TITLE
[Bugfix] Fix group:raid tag not hiding prefixes/suffixes while not in raid

### DIFF
--- a/Widgets/Texts/CustomFormats.lua
+++ b/Widgets/Texts/CustomFormats.lua
@@ -803,7 +803,7 @@ W:AddTag("group", "GROUP_ROSTER_UPDATE", function(unit)
 end, "Group", "1-8")
 
 W:AddTag("group:raid", "GROUP_ROSTER_UPDATE", function(unit)
-    if not IsInRaid() then return "" end
+    if not IsInRaid() then return end
     local subgroup = Util:GetUnitSubgroup(unit)
     if subgroup then
         return FormatNumber(subgroup)


### PR DESCRIPTION
Hello,

When using Custom Text with the `group:raid` tag, if you add a prefix and/or a suffix then it will show it instead of hiding it when not in raid.

Here is the example
![image](https://github.com/user-attachments/assets/606e58ab-65ed-4809-8b2f-85d2a5fdf4d1)

