### PR TITLE
Fix zero division ClassBar

### DIFF
--- a/Widgets/Bars/ClassBar.lua
+++ b/Widgets/Bars/ClassBar.lua
@@ -446,12 +446,24 @@ local function UpdateRune(bar)
     -- When changing zones this API can return nil
     if start == nil then return end
 
+    if duration <= 0 then
+        bar:SetValue(1)
+        bar:StopRuneTimer()
+        return
+    end
+
     if runeReady then
         bar:SetValue(1)
         bar:StopRuneTimer()
     else
         local timeLeft = duration - (GetTime() - start)
+        if timeLeft < 0 then timeLeft = 0 end
+        
         local progress = 1 - (timeLeft / duration)
+        if progress ~= progress or progress == math.huge or progress == -math.huge then
+            progress = 0
+        end
+        
         bar:SetValue(progress)
         bar:StartRuneTimer()
     end


### PR DESCRIPTION
I was fighting Elisandre in Nighthold in Legion Remix with my Death Knight when I got the following error:

```
Message: ...ace/AddOns/Cell_UnitFrames/Widgets/Bars/ClassBar.lua:455: bad argument #1 to 'SetValue' (must be a finite number - Usage: self:SetValue(value))
Time: Tue Jan 13 20:15:22 2026
Count: 8
Stack:
[Interface/AddOns/Cell_UnitFrames/Widgets/Bars/ClassBar.lua]:455: in function 'UpdateRune'
[Interface/AddOns/Cell_UnitFrames/Widgets/Bars/ClassBar.lua]:471: in function 'callback'
[Interface/AddOns/Cell_UnitFrames/UnitFrames/EventMixin.lua]:52: in function '_OnEvent'
[Interface/AddOns/Cell_UnitFrames/UnitFrames/OnLoad.lua]:123: in function <...terface/AddOns/Cell_UnitFrames/UnitFrames/OnLoad.lua:110>

Locals:
bar = CUF_Player_ClassBarBar2 {
 index = 2
 PixelSnapDisabled = true
 border = Frame {
 }
 bg = Texture {
 }
}
start = 43861.497000
duration = 0
runeReady = false
timeLeft = -298.598000
progress = Infinite
```

I think Elisandes time rewind mechanics invalidates cooldown data or something like that.

The PR adds a Guard for division by zero and clamps timeLeft.
Progress is also checked for NaN and (negative) Infinity.